### PR TITLE
Documentation fix for chap02/QemuAArch64

### DIFF
--- a/src/chap02/QemuAArch64.md
+++ b/src/chap02/QemuAArch64.md
@@ -45,6 +45,7 @@ make -j$(nproc)
 ```bash
 # 请注意，qemu-9.0.1 的父目录可以随着你的实际安装位置灵活调整。另外需要把其放在 $PATH 变量开头。
 export PATH="/path/to/qemu-9.0.1/build:$PATH"
+```
 
 随后即可在当前终端 `source ~/.bashrc` 更新系统路径，或者直接重启一个新的终端。此时可以确认 qemu 版本，如果显示为 qemu-9.0.1，则表示安装成功：
 

--- a/src/chap02/QemuAArch64.md
+++ b/src/chap02/QemuAArch64.md
@@ -234,9 +234,7 @@ cp "${KERNEL_PATH}" platform/aarch64/qemu-gicv3/image/kernel/Image
 
 ```bash
 # 编译设备树
-cd platform/aarch64/qemu-gicv3/image/dts/
-make all
-cd -    # 回到 hvisor 目录
+make BID=aarch64/qemu-gicv3 dtb
 ```
 
 > 其实建议采用硬链接的方式，以便减轻磁盘空间的占用和方便根文件系统修改时同步。
@@ -244,7 +242,7 @@ cd -    # 回到 hvisor 目录
 之后在 hvisor 目录下，执行相应命令即可启动 hvisor。
 
 ```bash
-make ARCH=aarch64 LOG=info BOARD=qemu-gicv3 run
+make BID=aarch64/qemu-gicv3 LOG=info run
 ```
 
 执行后会进入 uboot 启动界面，该界面下执行：
@@ -328,7 +326,7 @@ sudo umount rootfs
 
 ```bash
 # 启动 QEMU
-make ARCH=aarch64 LOG=info BOARD=qemu-gicv3 run
+make BID=aarch64/qemu-gicv3 LOG=info run
 ```
 
 ```


### PR DESCRIPTION
This PR includes the following updates to `src/chap02/QemuAArch64.md`:

- Fixed a missing code block closure in the QEMU environment setup section.
- Simplified the make commands for device tree compilation and hvisor startup.
